### PR TITLE
SEO refresh: UK top-100 + road-trips (core-update recovery)

### DIFF
--- a/_posts/2026-03-13-best-podcasts-for-road-trips.markdown
+++ b/_posts/2026-03-13-best-podcasts-for-road-trips.markdown
@@ -6,8 +6,20 @@ featured-image: "/images/blog/charts/best-podcasts-for-road-trips/collage-banner
 featured-image-alt: "Podcasts for road trips"
 description: "S-Town, Casefile and The Rest Is History — bingeable long-form podcasts with hours of gripping stories to make any long drive or road trip fly by."
 permalink: /blog/best-podcasts-for-road-trips
+podcasts:
+  - "S-Town"
+  - "Casefile True Crime"
+  - "Radiolab"
+  - "Heavyweight"
+  - "Revisionist History"
+  - "99% Invisible"
+  - "Armchair Expert"
+  - "No Such Thing As A Fish"
+  - "Stuff You Should Know"
+  - "The Rest Is History"
 author: "Jonathan Wilson"
 authorImage: "/images/blog/me.png"
+date-modified: "2026-05-31"
 ---
 
 <p>The best road trip podcasts aren't just background noise — they're the ones that make you sit in the car park for ten minutes because you need to hear what happens next. Here are 10 shows built for long drives: serialised stories, deep dives, and conversations so good you'll wish the journey was longer.</p>

--- a/_posts/2026-03-13-top-100-best-uk-podcasts.markdown
+++ b/_posts/2026-03-13-top-100-best-uk-podcasts.markdown
@@ -4,11 +4,23 @@ title: "100 Best UK Podcasts — The Ultimate List (2026)"
 categories: Podcast
 featured-image: "/images/blog/charts/100UK2020/collage-banner.jpg"
 featured-image-alt: "Best UK podcasts list"
-description: "The definitive list of the best British podcasts across true crime, comedy, news and culture. Ranked using Apple Charts and real listener data."
+description: "The best British podcasts in 2026 — from The Rest Is Politics and The Diary of a CEO to Off Menu. Ranked using Apple UK Charts and listener data."
 permalink: /blog/charts/top-100-best-uk-podcasts
 redirect_from: /blog/charts/top-100-best-uk-podcasts-2020
+podcasts:
+  - "The Rest Is Politics"
+  - "The Diary of a CEO"
+  - "Off Menu with Ed Gamble & James Acaster"
+  - "The News Agents"
+  - "Shagged Married Annoyed"
+  - "The Rest Is History"
+  - "No Such Thing As A Fish"
+  - "Desert Island Discs"
+  - "Parenting Hell"
+  - "The High Performance Podcast"
 author: "Jonathan Wilson"
 authorImage: "/images/blog/me.png"
+date-modified: "2026-06-17"
 ---
 
 <br>


### PR DESCRIPTION
Recovery work for the ~40% organic decline that hit the **"best [X] podcasts 2026" listicle cluster** during the **May 2026 broad core update** (cliff: week of 24 May). The homepage and true-crime held; date-stamped listicles aged out as Google promoted fresher competitors.

Applies the same **`date-modified` + `ItemList` freshness pattern** that kept the true-crime post stable through the update.

## Changes
- **`top-100-best-uk-podcasts`** (biggest single loss: −61 clicks, pos 12.8→22.7)
  - Added `podcasts:` ItemList (top 10 shows) → renders schema.org `ItemList` + `dateModified`
  - `date-modified: 2026-06-17`
  - Rewrote meta description to lead with real show names (Rest Is Politics, Diary of a CEO, Off Menu) for CTR
  - **Title unchanged** — true-crime/road-trips recovered *without* title edits; preserving existing equity
- **`best-podcasts-for-road-trips`** (pos 8.8→14.1) — folds in an orphaned local refresh (ItemList + `date-modified`) that was committed but never pushed

## Verified
- `jekyll build` clean (0.9s, no errors)
- Rendered HTML confirmed to contain `dateModified`, `2026-06-17`, `ItemList`/`itemListElement`, and the new description

Won't go live until merged (GitHub Pages deploys from `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)