### PR TITLE
SEO refresh for July 2026

### DIFF
--- a/_posts/2026-03-13-best-documentary-podcasts.markdown
+++ b/_posts/2026-03-13-best-documentary-podcasts.markdown
@@ -1,18 +1,23 @@
 ---
 layout: post
-title: "Best Documentary Podcasts (2026)"
+title: "Best Documentary Podcasts (Updated July 2026)"
 categories: Podcast
 featured-image: "/images/blog/charts/best-documentary-podcasts/collage-banner.jpg"
 featured-image-alt: "Documentary podcasts collection"
-description: "Radiolab, Serial, 99% Invisible, Darknet Diaries and more — the 10 best narrative documentary podcasts worth your time in 2026."
+description: "Radiolab, Serial, 99% Invisible, Darknet Diaries and more — the 10 best documentary podcasts to listen to in July 2026."
 permalink: /blog/best-documentary-podcasts
 author: "Jonathan Wilson"
 authorImage: "/images/blog/me.png"
+date-modified: 2026-07-01
 ---
 
 <p>Documentary podcasts do something no other medium can: they put you inside a story for hours, with nothing but voices, sound and your own imagination. These 10 shows are the best at it right now — deeply reported, beautifully produced, and all actively releasing new episodes.</p>
 
 {% include callToActionRow.html %}
+
+<h3>What's new this July 2026</h3>
+<p>Radiolab and 99% Invisible are both releasing strong new episodes this summer, and Serial's long-form investigative format remains the benchmark for the genre — this list continues to hold up.</p>
+<br>
 
 <br>
 

--- a/_posts/2026-03-13-best-economics-podcasts.markdown
+++ b/_posts/2026-03-13-best-economics-podcasts.markdown
@@ -1,18 +1,23 @@
 ---
 layout: post
-title: "Best Economics Podcasts (2026)"
+title: "Best Economics Podcasts (Updated July 2026)"
 categories: Podcast
 featured-image: "/images/blog/charts/best-economics-podcasts/collage-banner.jpg"
 featured-image-alt: "Economics podcasts collection"
-description: "Planet Money, Freakonomics Radio, EconTalk and more — 10 economics podcasts that make macro, policy, and economic thinking genuinely interesting."
+description: "Planet Money, Freakonomics Radio, EconTalk and more — 10 economics podcasts making macro and policy genuinely interesting in July 2026."
 permalink: /blog/best-economics-podcasts
 author: "Jonathan Wilson"
 authorImage: "/images/blog/me.png"
+date-modified: 2026-07-01
 ---
 
 <p>Economics shapes everything — housing, wages, trade wars, the price of eggs — but most coverage is either too dry or too shallow. These 10 podcasts actually make economic thinking accessible and worth your time.</p>
 
 {% include callToActionRow.html %}
+
+<h3>What's new this July 2026</h3>
+<p>Planet Money and Odd Lots remain essential for making sense of mid-2026's trade shifts and inflation picture — both are releasing timely episodes that cut through the noise better than any news coverage.</p>
+<br>
 
 <br>
 

--- a/_posts/2026-03-13-best-health-fitness-podcasts.markdown
+++ b/_posts/2026-03-13-best-health-fitness-podcasts.markdown
@@ -1,18 +1,23 @@
 ---
 layout: post
-title: "Best Health & Fitness Podcasts (2026)"
+title: "Best Health & Fitness Podcasts (Updated July 2026)"
 categories: Podcast
 featured-image: "/images/blog/charts/best-health-fitness-podcasts/collage-banner.jpg"
 featured-image-alt: "Health and fitness podcasts collection"
-description: "Huberman Lab, ZOE Science & Nutrition, The Peter Attia Drive and 7 more — the best health and fitness podcasts to listen to in 2026."
+description: "Huberman Lab, ZOE Science & Nutrition, The Peter Attia Drive and 7 more — the best health and fitness podcasts to listen to in July 2026."
 permalink: /blog/best-health-fitness-podcasts
 author: "Jonathan Wilson"
 authorImage: "/images/blog/me.png"
+date-modified: 2026-07-01
 ---
 
 <p>Health podcasts used to mean vague wellness advice and supplement ads. The best ones now bring real science, proper credentials and genuinely useful information you can apply the same day. Here are 10 that are worth your time in 2026.</p>
 
 {% include callToActionRow.html %}
+
+<h3>What's new this July 2026</h3>
+<p>Huberman Lab and The Peter Attia Drive continue to set the standard for evidence-based health content, with recent series covering strength training longevity protocols and metabolic health that are as useful as ever.</p>
+<br>
 
 <br>
 


### PR DESCRIPTION
Monthly freshness refresh for 3 oldest `best-*-podcasts` posts.

**Posts updated:**
- best-documentary-podcasts
- best-economics-podcasts
- best-health-fitness-podcasts

**Changes per post:** title → (Updated July 2026), `date-modified` bumped to 2026-07-01, meta description refreshed with July 2026 date, new "What's new this July 2026" intro block inserted after first `{% include callToActionRow.html %}`.

Auto-generated by the monthly best-podcasts SEO refresh routine. Review and merge to deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KE9PeMQKPFDLbA2Vgy47X7)_