### PR TITLE
SEO refresh for August 2026

### DIFF
--- a/_posts/2026-03-13-best-history-podcasts.markdown
+++ b/_posts/2026-03-13-best-history-podcasts.markdown
@@ -1,19 +1,22 @@
 ---
 layout: post
-title: "Best History Podcasts (2026)"
+title: "Best History Podcasts (Updated August 2026)"
 categories: Podcast
 featured-image: "/images/blog/charts/best-history-podcasts/collage-banner.jpg"
 featured-image-alt: "History podcasts collection"
-description: "The Rest Is History, Hardcore History, Fall of Civilizations and 7 more — the best history podcasts worth your time in 2026."
+description: "The Rest Is History, Hardcore History, Fall of Civilizations and more — the best history podcasts worth your time, updated August 2026."
 permalink: /blog/best-history-podcasts
 author: "Jonathan Wilson"
 authorImage: "/images/blog/me.png"
+date-modified: 2026-08-01
 ---
 
 <p>History podcasts are having a moment. Whether you want a cinematic deep dive into ancient Rome or a quick 30-minute episode on a topic you never knew existed, there's a show for you. Here are 10 of the best.</p>
 
 {% include callToActionRow.html %}
 
+<h3>What's new this August 2026</h3>
+<p>The Rest Is History and Hardcore History remain the gold standard for history podcasting — both continue releasing landmark episodes that earn their place at the top of any listening list.</p>
 <br>
 
 <h3><a class="text-info" href="https://podcasts.apple.com/gb/search?term=The+Rest+Is+History">1. The Rest Is History</a></h3>

--- a/_posts/2026-03-13-best-horror-podcasts.markdown
+++ b/_posts/2026-03-13-best-horror-podcasts.markdown
@@ -1,13 +1,14 @@
 ---
 layout: post
-title: "10 Best Horror Podcasts (2026) — Terrifying Stories to Keep You Up"
+title: "10 Best Horror Podcasts (Updated August 2026) — Terrifying Stories to Keep You Up"
 categories: Podcast
 featured-image: "/images/blog/charts/best-horror-podcasts/collage-banner.jpg"
 featured-image-alt: "Horror podcasts collection"
-description: "The Magnus Protocol, Lore and The NoSleep Podcast — the best horror podcasts for truly terrifying fiction, dark folklore and real unexplained encounters."
+description: "The Magnus Protocol, Lore and The NoSleep Podcast — the best horror podcasts for terrifying fiction and dark folklore, updated August 2026."
 permalink: /blog/best-horror-podcasts
 author: "Jonathan Wilson"
 authorImage: "/images/blog/me.png"
+date-modified: 2026-08-01
 ---
 
 <p>Horror podcasts hit different. No jump scares, no visual cues — just a voice in your ears and your own imagination filling in the gaps. These ten are the best of the genre right now, covering everything from scripted audio dramas to real paranormal encounters, all actively releasing new episodes.</p>
@@ -16,6 +17,8 @@ authorImage: "/images/blog/me.png"
 
 {% include callToActionRow.html %}
 
+<h3>What's new this August 2026</h3>
+<p>The Magnus Protocol and Lore remain the standout picks for horror audio — both series continue delivering consistently unsettling episodes that hold up against anything new entering the space.</p>
 <br>
 
 <h3><a class="text-info" href="https://podcasts.apple.com/gb/search?term=The+Magnus+Protocol">1. The Magnus Protocol</a></h3>

--- a/_posts/2026-03-13-best-language-learning-podcasts.markdown
+++ b/_posts/2026-03-13-best-language-learning-podcasts.markdown
@@ -1,19 +1,22 @@
 ---
 layout: post
-title: "Best Language Learning Podcasts (2026)"
+title: "Best Language Learning Podcasts (Updated August 2026)"
 categories: Podcast
 featured-image: "/images/blog/charts/best-language-learning-podcasts/collage-banner.jpg"
 featured-image-alt: "Language learning podcasts collection"
-description: "Coffee Break Spanish, InnerFrench, Nihongo con Teppei and 7 more — the best language learning podcasts for 2026 across 8 different languages."
+description: "Coffee Break Spanish, InnerFrench, Nihongo con Teppei and more — the best language learning podcasts across 8 languages, updated August 2026."
 permalink: /blog/best-language-learning-podcasts
 author: "Jonathan Wilson"
 authorImage: "/images/blog/me.png"
+date-modified: 2026-08-01
 ---
 
 <p>Podcasts are one of the most effective ways to learn a language — you get native speakers in your ears, real conversations, and you can fit it into dead time like commutes and dog walks. Here are 10 of the best, covering everything from Spanish and French to Japanese and Korean.</p>
 
 {% include callToActionRow.html %}
 
+<h3>What's new this August 2026</h3>
+<p>Coffee Break Spanish and InnerFrench remain the most consistent options for structured learning — their steady release schedules and quality production continue to make them essential listening in 2026.</p>
 <br>
 
 <h3><a class="text-info" href="https://podcasts.apple.com/gb/search?term=Coffee+Break+Spanish">1. Coffee Break Spanish</a></h3>


### PR DESCRIPTION
Monthly freshness refresh for 3 oldest `best-*-podcasts` posts.

**Posts updated:**
- best-history-podcasts
- best-horror-podcasts
- best-language-learning-podcasts

**Changes per post:** title → (Updated August 2026), `date-modified` bumped to 2026-08-01, meta description refreshed with current month/year, new "What's new this August 2026" intro block inserted after the first `{% include callToActionRow.html %}`.

Auto-generated by the monthly best-podcasts SEO refresh routine. Review and merge to deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AV3tGptDjDivDNydwrwCkh)_